### PR TITLE
address early feedback and bugs

### DIFF
--- a/src/membership/components/MemberForm.jsx
+++ b/src/membership/components/MemberForm.jsx
@@ -180,8 +180,8 @@ export default class MemberForm extends React.Component {
         </Col>
         <Col xs={12} style={hintStyle}>{this.msg('public_name_hint')}</Col>
       </Row>
-      {{ badgeName }}
-      {{ addressFields }}
+      { badgeName }
+      { addressFields }
       {!newMember ? (
         <AddPaperPubs
           prices={prices}

--- a/src/membership/components/MemberForm.jsx
+++ b/src/membership/components/MemberForm.jsx
@@ -99,15 +99,6 @@ export default class MemberForm extends React.Component {
       tabIndex
     }
 
-    const haveBadgeName = false; // TODO: once it exists in the backend, toggle
-    const badgeName = haveBadgeName ? (
-      <Row>
-        <Col xs={12}>
-          <TextInput { ...inputProps } path='badgename' />
-        </Col>
-      </Row>
-    ) : null;
-
     // TODO: once 'zipcode' and 'address' exists in the backend, toggle this:
     const haveAddressAndZipCode = false;
     const addressFields = haveAddressAndZipCode ? (<div>
@@ -180,7 +171,11 @@ export default class MemberForm extends React.Component {
         </Col>
         <Col xs={12} style={hintStyle}>{this.msg('public_name_hint')}</Col>
       </Row>
-      { badgeName }
+      <Row>
+        <Col xs={12}>
+          <TextInput { ...inputProps } path='badge_text' />
+        </Col>
+      </Row>
       { addressFields }
       {!newMember ? (
         <AddPaperPubs

--- a/src/membership/components/MemberForm.jsx
+++ b/src/membership/components/MemberForm.jsx
@@ -99,9 +99,9 @@ export default class MemberForm extends React.Component {
       tabIndex
     }
 
-    // TODO: once 'zipcode' and 'address' exists in the backend, toggle this:
-    const haveAddressAndZipCode = false;
-    const addressFields = haveAddressAndZipCode ? (<div>
+    // TODO: once 'postcode' and 'address' exists in the backend, toggle this:
+    const haveAddressAndPostcode = !!localStorage.haveAddressAndPostcode;
+    const addressFields = haveAddressAndPostcode ? (<div>
       <Row>
         <Col xs={12}>
           <TextInput { ...inputProps } path='address' />
@@ -117,7 +117,7 @@ export default class MemberForm extends React.Component {
       </Row>
       <Row>
         <Col xs={12} sm={6}>
-          <TextInput { ...inputProps } path='zipcode' />
+          <TextInput { ...inputProps } path='postcode' />
         </Col>
         <Col xs={12} sm={6}>
           <TextInput { ...inputProps } path='country' />

--- a/src/membership/messages/daypass.json
+++ b/src/membership/messages/daypass.json
@@ -8,8 +8,11 @@
   "public_last_name": "Family Name For Publications",
   "public_name_hint": "How shall we list you in public? Leave these fields blank if you'd prefer we don't list you at all on our website or elsewhere. If you give us two names, we'll use the second for alphabetization (either can contain spaces). A few months before the con, you'll be able to separately customize the text of your badge.",
   "city": "City / Town",
+  "address": "Address",
+  "postcode": "Postal Code",
   "state": "State / Province / Region",
   "country": "Country",
+  "badge_text": "Badge Name",
   "location_hint": "",
   "paper_pubs": {
     "name": "Paper pubs name",

--- a/src/membership/messages/en.json
+++ b/src/membership/messages/en.json
@@ -8,8 +8,11 @@
   "public_last_name": "Family Name For Publications",
   "public_name_hint": "How shall we list you in public? Leave these fields blank if you'd prefer we don't list you at all on our website or elsewhere. If you give us two names, we'll use the second for alphabetization (either can contain spaces). A few months before the con, you'll be able to separately customize the text of your badge. A few months before the con, you'll be able to separately customize the text of your badge.",
   "city": "City / Town",
+  "address": "Address",
+  "postcode": "Postal Code",
   "state": "State / Province / Region",
   "country": "Country",
+  "badge_text": "Badge Name",
   "location_hint": "",
   "paper_pubs": {
     "name": "Paper pubs name",


### PR DESCRIPTION
* [x] fixes js syntax error in registration
* [x] reuse pre-existing `badge_text` field
* [x] rename `zipcode` field `postcode`
* [x] add a preview test mode given `localStorage.haveAddressAndPostcode = true`
* [x] populate missing UI field names `Postal Code`, `Address`, and `Badge Name`