### PR TITLE
Temporary /upgraders route for WorldCon75 folks this weekend

### DIFF
--- a/make-emailHashToLoginKey.pike
+++ b/make-emailHashToLoginKey.pike
@@ -1,0 +1,18 @@
+#! /usr/bin/env pike
+
+string salt = "Salted!";
+
+string hash(string email) {
+  return String.string2hex(Crypto.MD5.hash(salt + lower_case(email)));
+}
+
+string map_csv_line(string csv) {
+  array(string) fields = csv / ",";
+  return sprintf("\"%s\": \"%s\"", hash(fields[0]), fields[1]);
+}
+
+int main(int argc, array(string) argv) {
+  array(string) lines = Stdio.stdin.read() / "\n" - ({""});
+  string json = "{ " + Array.map(lines, map_csv_line) * "\n, " + "\n}\n";
+  write(json);
+}

--- a/src/app/components/InstaLoginHack.jsx
+++ b/src/app/components/InstaLoginHack.jsx
@@ -1,0 +1,90 @@
+import React, { PropTypes } from 'react'
+import { connect } from 'react-redux'
+import { Card, CardHeader, CardText } from 'material-ui/Card'
+import RaisedButton from 'material-ui/RaisedButton'
+import TextField from 'material-ui/TextField'
+
+import { keyLogin } from '../actions/auth';
+import { hex: md5 } from '../../lib/md5';
+
+/**
+ * This Dublin2019 component is made for use at WorldCon75 Helsinki alone,
+ * to run on the terminals for people upgrading their membership.
+ *
+ * It bypasses the login link emailing step, by using a emailHashToLoginKey
+ * look-up table from salted, md5 hashed emails, to that email's login key.
+ * (if you know someone's voting email address you can buy them an upgrade)
+ */
+
+// if we need this login to go to some particular place, pick which here
+const loginPath = (location.hash.match(/^#to=([^&]+)/) || [])[1];
+
+// md5.hex(`Salted!${email.toLowerCase()}`) => login key
+const emailHashToLoginKey =
+{ '390a0e6d453de00e84013054a18f525a': 'ISrypVXEQk3E' // oyasumi+test2@gmail.com
+};
+
+const getKeyForEmail(email = '') {
+  let salted = `Salted!${email.toLowerCase()}`;
+  return emailHashToLoginKey[md5(salted)];
+};
+
+class InstaLoginHack extends React.Component {
+
+  static propTypes = {
+    cardStyle: PropTypes.object,
+    keyLogin: PropTypes.func.isRequired,
+  }
+
+  state = {
+    email: ''
+  }
+
+  render() {
+    const { cardStyle, keyLogin } = this.props;
+    const { email } = this.state;
+    const validEmail = email && /.@.*\../.test(email);
+    const key = validEmail && getKeyForEmail(email);
+
+    return <div>
+      <Card style={cardStyle}>
+        <CardHeader
+          title="Login to Upgrade Existing Membership"
+          style={{ fontWeight: 600 }}
+        />
+        <CardText style={{ marginTop: -16 }}>
+          <div className="html-container">
+            <p>
+              If you voted in Site Selection in Helsinki,
+              enter the email address you used for that below.
+            </p>
+            <p>
+              If you are a Dublin BID Presupporter / Backer / Friend / Super Friend,
+              please enter the email address you used for that, instead.
+            </p>
+          </div>
+          <form onSubmit={() => key && keyLogin(email, key, loginPath)}>
+            <TextField
+              autoFocus={true}
+              id="email"
+              fullWidth={true}
+              floatingLabelText="Email"
+              value={email}
+              onChange={(_, email) => this.setState({ email })}
+            />
+            <RaisedButton
+              label={key ? 'Enter Email Address' : 'Login to Upgrade'}
+              fullWidth={true}
+              primary={true}
+              disabled={!validEmail || !key}
+              style={{ marginTop: 12 }}
+              onTouchTap={() => keyLogin(email, key, loginPath)}
+            />
+          </form>
+        </CardText>
+      </Card>
+    </div>
+  }
+}
+
+export default connect(null, { keyLogin })(InstaLoginHack);

--- a/src/app/components/Upgraders.jsx
+++ b/src/app/components/Upgraders.jsx
@@ -1,0 +1,68 @@
+import { List } from 'immutable'
+import React from 'react'
+import { connect } from 'react-redux'
+import { push } from 'react-router-redux'
+const { Col, Row } = require('react-flexbox-grid');
+const ImmutablePropTypes = require('react-immutable-proptypes');
+
+import { setScene } from '../actions/app'
+import InstaLoginHack from './InstaLoginHack'
+import MemberCard from '../../membership/components/MemberCard'
+import NewMemberCard from '../../membership/components/NewMemberCard'
+
+class Upgraders extends React.Component {
+
+  static propTypes = {
+    people: ImmutablePropTypes.list.isRequired,
+    push: React.PropTypes.func.isRequired,
+    setScene: React.PropTypes.func.isRequired
+  }
+
+  componentDidMount() {
+    const { setScene } = this.props;
+    setScene({ title: 'Membership Upgrades', dockSidebar: false });
+  }
+
+  get memberCards() {
+    const { people } = this.props;
+    const hugoCount = people.reduce((sum, m) => (
+      sum + (m.get('can_hugo_nominate') || m.get('can_hugo_vote') ? 1 : 0)
+    ), 0);
+    return people.map((member, key) => (
+      <MemberCard
+        key={key}
+        member={member}
+        showHugoActions={hugoCount === 10}
+      />
+    ));
+  }
+
+  render() {
+    const { people, push } = this.props
+    const isLoggedIn = !!(people && people.size)
+    const upgradePath = people && people.size === 1
+      ? `/upgrade/${people.first().get('id')}` : '/upgrade/'
+    return <Row style={{ marginBottom: -24 }}>
+      <Col xs={12} sm={6} lg={4} lgOffset={2}>
+        {isLoggedIn ? this.memberCards : <InstaLoginHack/>}
+      </Col>
+      <Col xs={12} sm={6} lg={4}>
+        <NewMemberCard
+          category="upgrade"
+          disabled={!isLoggedIn}
+          expandable={isLoggedIn}
+          onSelectType={() => push(upgradePath)}
+        />
+      </Col>
+    </Row>
+  }
+}
+
+export default connect(
+  ({ purchase, user }) => ({
+    people: user.get('people') || List(),
+  }), {
+    push,
+    setScene
+  }
+)(Upgraders);

--- a/src/lib/md5.js
+++ b/src/lib/md5.js
@@ -1,0 +1,259 @@
+/*
+ * A JavaScript implementation of the RSA Data Security, Inc. MD5 Message
+ * Digest Algorithm, as defined in RFC 1321.
+ * Version 2.1 Copyright (C) Paul Johnston 1999 - 2002.
+ * Other contributors: Greg Holt, Andrew Kepert, Ydnar, Lostinet
+ * Distributed under the BSD License
+ * See http://pajhome.org.uk/crypt/md5 for more info.
+ */
+
+var MD5 = (function() {
+
+/*
+ * Calculate the MD5 of an array of little-endian words, and a bit length
+ */
+function core_md5(x, len) {
+  /* append padding */
+  x[len >> 5] |= 0x80 << ((len) % 32);
+  x[(((len + 64) >>> 9) << 4) + 14] = len;
+
+  var a =  1732584193;
+  var b = -271733879;
+  var c = -1732584194;
+  var d =  271733878;
+
+  for (var i = 0; i < x.length; i += 16) {
+    var olda = a;
+    var oldb = b;
+    var oldc = c;
+    var oldd = d;
+
+    a = md5_ff(a, b, c, d, x[i+ 0], 7 , -680876936);
+    d = md5_ff(d, a, b, c, x[i+ 1], 12, -389564586);
+    c = md5_ff(c, d, a, b, x[i+ 2], 17,  606105819);
+    b = md5_ff(b, c, d, a, x[i+ 3], 22, -1044525330);
+    a = md5_ff(a, b, c, d, x[i+ 4], 7 , -176418897);
+    d = md5_ff(d, a, b, c, x[i+ 5], 12,  1200080426);
+    c = md5_ff(c, d, a, b, x[i+ 6], 17, -1473231341);
+    b = md5_ff(b, c, d, a, x[i+ 7], 22, -45705983);
+    a = md5_ff(a, b, c, d, x[i+ 8], 7 ,  1770035416);
+    d = md5_ff(d, a, b, c, x[i+ 9], 12, -1958414417);
+    c = md5_ff(c, d, a, b, x[i+10], 17, -42063);
+    b = md5_ff(b, c, d, a, x[i+11], 22, -1990404162);
+    a = md5_ff(a, b, c, d, x[i+12], 7 ,  1804603682);
+    d = md5_ff(d, a, b, c, x[i+13], 12, -40341101);
+    c = md5_ff(c, d, a, b, x[i+14], 17, -1502002290);
+    b = md5_ff(b, c, d, a, x[i+15], 22,  1236535329);
+
+    a = md5_gg(a, b, c, d, x[i+ 1], 5 , -165796510);
+    d = md5_gg(d, a, b, c, x[i+ 6], 9 , -1069501632);
+    c = md5_gg(c, d, a, b, x[i+11], 14,  643717713);
+    b = md5_gg(b, c, d, a, x[i+ 0], 20, -373897302);
+    a = md5_gg(a, b, c, d, x[i+ 5], 5 , -701558691);
+    d = md5_gg(d, a, b, c, x[i+10], 9 ,  38016083);
+    c = md5_gg(c, d, a, b, x[i+15], 14, -660478335);
+    b = md5_gg(b, c, d, a, x[i+ 4], 20, -405537848);
+    a = md5_gg(a, b, c, d, x[i+ 9], 5 ,  568446438);
+    d = md5_gg(d, a, b, c, x[i+14], 9 , -1019803690);
+    c = md5_gg(c, d, a, b, x[i+ 3], 14, -187363961);
+    b = md5_gg(b, c, d, a, x[i+ 8], 20,  1163531501);
+    a = md5_gg(a, b, c, d, x[i+13], 5 , -1444681467);
+    d = md5_gg(d, a, b, c, x[i+ 2], 9 , -51403784);
+    c = md5_gg(c, d, a, b, x[i+ 7], 14,  1735328473);
+    b = md5_gg(b, c, d, a, x[i+12], 20, -1926607734);
+
+    a = md5_hh(a, b, c, d, x[i+ 5], 4 , -378558);
+    d = md5_hh(d, a, b, c, x[i+ 8], 11, -2022574463);
+    c = md5_hh(c, d, a, b, x[i+11], 16,  1839030562);
+    b = md5_hh(b, c, d, a, x[i+14], 23, -35309556);
+    a = md5_hh(a, b, c, d, x[i+ 1], 4 , -1530992060);
+    d = md5_hh(d, a, b, c, x[i+ 4], 11,  1272893353);
+    c = md5_hh(c, d, a, b, x[i+ 7], 16, -155497632);
+    b = md5_hh(b, c, d, a, x[i+10], 23, -1094730640);
+    a = md5_hh(a, b, c, d, x[i+13], 4 ,  681279174);
+    d = md5_hh(d, a, b, c, x[i+ 0], 11, -358537222);
+    c = md5_hh(c, d, a, b, x[i+ 3], 16, -722521979);
+    b = md5_hh(b, c, d, a, x[i+ 6], 23,  76029189);
+    a = md5_hh(a, b, c, d, x[i+ 9], 4 , -640364487);
+    d = md5_hh(d, a, b, c, x[i+12], 11, -421815835);
+    c = md5_hh(c, d, a, b, x[i+15], 16,  530742520);
+    b = md5_hh(b, c, d, a, x[i+ 2], 23, -995338651);
+
+    a = md5_ii(a, b, c, d, x[i+ 0], 6 , -198630844);
+    d = md5_ii(d, a, b, c, x[i+ 7], 10,  1126891415);
+    c = md5_ii(c, d, a, b, x[i+14], 15, -1416354905);
+    b = md5_ii(b, c, d, a, x[i+ 5], 21, -57434055);
+    a = md5_ii(a, b, c, d, x[i+12], 6 ,  1700485571);
+    d = md5_ii(d, a, b, c, x[i+ 3], 10, -1894986606);
+    c = md5_ii(c, d, a, b, x[i+10], 15, -1051523);
+    b = md5_ii(b, c, d, a, x[i+ 1], 21, -2054922799);
+    a = md5_ii(a, b, c, d, x[i+ 8], 6 ,  1873313359);
+    d = md5_ii(d, a, b, c, x[i+15], 10, -30611744);
+    c = md5_ii(c, d, a, b, x[i+ 6], 15, -1560198380);
+    b = md5_ii(b, c, d, a, x[i+13], 21,  1309151649);
+    a = md5_ii(a, b, c, d, x[i+ 4], 6 , -145523070);
+    d = md5_ii(d, a, b, c, x[i+11], 10, -1120210379);
+    c = md5_ii(c, d, a, b, x[i+ 2], 15,  718787259);
+    b = md5_ii(b, c, d, a, x[i+ 9], 21, -343485551);
+
+    a = safe_add(a, olda);
+    b = safe_add(b, oldb);
+    c = safe_add(c, oldc);
+    d = safe_add(d, oldd);
+  }
+  return [a, b, c, d];
+}
+
+/*
+ * These functions implement the four basic operations the algorithm uses.
+ */
+function md5_cmn(q, a, b, x, s, t) {
+  return safe_add(bit_rol(safe_add(safe_add(a, q), safe_add(x, t)), s),b);
+}
+function md5_ff(a, b, c, d, x, s, t) {
+  return md5_cmn((b & c) | ((~b) & d), a, b, x, s, t);
+}
+function md5_gg(a, b, c, d, x, s, t) {
+  return md5_cmn((b & d) | (c & (~d)), a, b, x, s, t);
+}
+function md5_hh(a, b, c, d, x, s, t) {
+  return md5_cmn(b ^ c ^ d, a, b, x, s, t);
+}
+function md5_ii(a, b, c, d, x, s, t) {
+  return md5_cmn(c ^ (b | (~d)), a, b, x, s, t);
+}
+
+/*
+ * Calculate the HMAC-MD5, of a key and some data
+ */
+function core_hmac_md5(key, data) {
+  var bkey = str2binl(key);
+  if(bkey.length > 16) bkey = core_md5(bkey, key.length * MD5.chrsz);
+
+  var ipad = [], opad = [];
+  for(var i = 0; i < 16; i++) {
+    ipad[i] = bkey[i] ^ 0x36363636;
+    opad[i] = bkey[i] ^ 0x5C5C5C5C;
+  }
+
+  var hash = core_md5(ipad.concat(str2binl(data)), 512 + data.length * MD5.chrsz);
+  return core_md5(opad.concat(hash), 512 + 128);
+}
+
+/*
+ * Add integers, wrapping at 2^32. This uses 16-bit operations internally
+ * to work around bugs in some JS interpreters.
+ */
+function safe_add(x, y) {
+  var lsw = (x & 0xFFFF) + (y & 0xFFFF);
+  var msw = (x >> 16) + (y >> 16) + (lsw >> 16);
+  return (msw << 16) | (lsw & 0xFFFF);
+}
+
+/*
+ * Bitwise rotate a 32-bit number to the left.
+ */
+function bit_rol(num, cnt) {
+  return (num << cnt) | (num >>> (32 - cnt));
+}
+
+/*
+ * Convert a string to an array of little-endian words
+ * If chrsz is ASCII, characters >255 have their hi-byte silently ignored.
+ */
+function str2binl(str) {
+  var bin = [], chrsz = MD5.chrsz;
+  var mask = (1 << chrsz) - 1;
+  for(var i = 0; i < str.length * chrsz; i += chrsz)
+    bin[i>>5] |= (str.charCodeAt(i / chrsz) & mask) << (i%32);
+  return bin;
+}
+
+/*
+ * Convert an array of little-endian words to a string
+ */
+function binl2str(bin) {
+  var str = "", chrsz = MD5.chrsz;
+  var mask = (1 << chrsz) - 1;
+  for(var i = 0; i < bin.length * 32; i += chrsz)
+    str += String.fromCharCode((bin[i>>5] >>> (i % 32)) & mask);
+  return str;
+}
+
+/*
+ * Convert an array of little-endian words to a hex string.
+ */
+function binl2hex(binarray) {
+  var hex_tab = MD5.hexcase ? "0123456789ABCDEF" : "0123456789abcdef";
+  var str = "";
+  for(var i = 0; i < binarray.length * 4; i++) {
+    str += hex_tab.charAt((binarray[i>>2] >> ((i%4)*8+4)) & 0xF) +
+           hex_tab.charAt((binarray[i>>2] >> ((i%4)*8  )) & 0xF);
+  }
+  return str;
+}
+
+/*
+ * Convert an array of little-endian words to a base-64 string
+ */
+function binl2b64(binarray) {
+  var tab = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  var str = "";
+  for(var i = 0; i < binarray.length * 4; i += 3) {
+    var triplet = (((binarray[i   >> 2] >> 8 * ( i   %4)) & 0xFF) << 16)
+                | (((binarray[i+1 >> 2] >> 8 * ((i+1)%4)) & 0xFF) << 8 )
+                |  ((binarray[i+2 >> 2] >> 8 * ((i+2)%4)) & 0xFF);
+    for(var j = 0; j < 4; j++) {
+      if(i * 8 + j * 6 > binarray.length * 32) str += MD5.b64pad;
+      else str += tab.charAt((triplet >> 6*(3-j)) & 0x3F);
+    }
+  }
+  return str;
+}
+
+  return {
+/*
+ * Configurable variables. You may need to tweak these to be compatible with
+ * the server-side, but the defaults work in most cases.
+ */
+    hexcase: 0, // hex output format. 0 - lowercase; 1 - uppercase
+    b64pad: "", // base-64 pad character. "=" for strict RFC compliance
+    chrsz: 8,   // bits per input character. 8 - ASCII; 16 - Unicode
+
+/*
+ * These are the functions you'll usually want to call
+ * They take string arguments and return either hex or base-64 encoded strings
+ */
+    hex: function(s) {
+      return binl2hex( core_md5( str2binl( s ), s.length * MD5.chrsz ) );
+    },
+
+    base64: function(s) {
+      return binl2b64( core_md5( str2binl( s ), s.length * MD5.chrsz ) );
+    },
+
+    string: function(s) {
+      return binl2str( core_md5( str2binl( s ), s.length * MD5.chrsz ) );
+    },
+
+    hmac:{
+      hex: function(key, data) {
+        return binl2hex( core_hmac_md5( key, data ) );
+      },
+
+      base64: function(key, data) {
+        return binl2b64( core_hmac_md5( key, data ) );
+      },
+
+      string: function(key, data) {
+        return binl2str( core_hmac_md5( key, data ) );
+      }
+    },
+
+    test: function() { // Perform a simple self-test to see if the VM is working
+      return this.hex("abc") == "900150983cd24fb0d6963f7d28e17f72";
+    }
+  };
+})();
+
+export default MD5;

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -79,6 +79,7 @@ export default class AppRouter extends Route {
     const { history } = this.props
     return (
       <Router history={history}>
+        <Route path="/upgraders" component={Upgraders} />
         <Route path="/login/:email/:key" onEnter={this.doLogin} />
         <Route path="/login/:email/:key/:id" onEnter={this.doLogin} />
         <Route path="/" component={App} onChange={this.scrollUpOnChange} onEnter={this.checkAuth} >


### PR DESCRIPTION
This adds an `/upgraders` slimmed-down login/upgrade flow to run on our kiosk computers, so existing users get a kiosk-friendly flow that bypasses the email login link flow. It currently only knows the test user `oyasumi+test2@gmail.com`. To add more, replace the `emailHashToLoginKey` in `src/app/components/InstaLoginHack.jsx` with a better lookup table.

The easy way to make one is to pipe a `email,loginkey` csv through `make-emailHashToLoginKey.pike` also added in this pull request.