### PR TITLE
fix: the phone-reachable /new page, simplified

### DIFF
--- a/src/membership/components/NewMemberIndex.jsx
+++ b/src/membership/components/NewMemberIndex.jsx
@@ -30,6 +30,24 @@ class NewMemberIndex extends React.Component {
 
   render() {
     const { prices, push } = this.props;
+    // slimmed-down /new page (from phone nav) without day passes, et cetera:
+    return <Row style={{ marginBottom: -24 }}>
+      <Col
+        xs={12}
+        sm={6}
+        md={5} mdOffset={1}
+        lg={4} lgOffset={2}
+        style={{ paddingLeft: '0.75rem', paddingRight: '0.75rem' }}
+      >
+        <NewMemberCard
+          category="all"
+          expandable={true}
+          onSelectType={(type) => push(`/new/${type}`)}
+          prices={prices}
+        />
+      </Col>
+    </Row>;
+
     return <Row style={{ marginBottom: -24 }}>
       <Col
         xs={12}


### PR DESCRIPTION
The /new page, which was linked from the phone nav menu, looked not-great:

# Before

![before](https://user-images.githubusercontent.com/2459/29253697-782137ce-808d-11e7-8b39-defe3512147b.png)

# After

<img width="964" alt="afterwards" src="https://user-images.githubusercontent.com/2459/29253700-8663718a-808d-11e7-80bd-bb670569e4b5.png">
