### PR TITLE
fix: resume logout at / after any non-/upgraders login

### DIFF
--- a/src/membership/middleware.js
+++ b/src/membership/middleware.js
@@ -55,7 +55,9 @@ export default ({ dispatch }) => (next) => (action) => {
       api.GET('logout')
         .then(() => {
           next(action);
-          dispatch(push(localStorage.logoutPath || '/'));
+          const logoutTo = localStorage.logoutPath || '/';
+          dispatch(push(logoutTo));
+          delete localStorage.logoutPath;
         })
         .catch(handleError);
     } return;


### PR DESCRIPTION
People that ever visited the `/upgraders` route ended up stuck returning to that page after login (good for the kiosk-mode terminals, not good for web browsers), no matter if you went back to the "normal" site afterwards. Addressed in this fix.