### PR TITLE
docs: info about our kiosk mode setup for at-con membership upgrading

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ These are the front-end clients used by the Dublin 2019 Worldcon Bid,
 implemented as single-page react + redux apps. For the back-end code, please see
 [dublin2019/api](https://github.com/dublin2019/api).
 
+## Upgrader kiosks (the blue dell computers)
+
+At the convention, the e-mail login flow was cumbersome and failure prone,
+so we hacked up a custom one-off flow to run on the few upgrade kiosks,
+where a kiosk-mode browser tied to https://api.dublin2019.com/upgraders
+lets people log on their by e-mail alone from static email dumps we caught
+from the members table, lowercased, salted, hashed and truncated for size
+(and to avoid people walking off with a list of all member email addresses).
+
+It doesn't talk to any api server for this data – to reuse it as is,
+either drop an `email,logintoken` csv into `emails.csv` in the root dir
+or a ` email      | logintoken` paste into `emails.txt`, and run
+`make instaloginkeys.js`, commit, push, merge, and publish it to the site
+(`npm run build:deploy`, if all you did was to change js, such as this).
 
 ### Getting Started
 


### PR DESCRIPTION
Adding some docs for the upgrade kiosk route we hacked up at the con added to the README.

The dell computers themselves ran windows, and were equipped with a little `upgraders.bat` script on the desktop that ran something like this (easy to check in Notepad, if you have one of them on hand, but I think from memory that this might be the exact look):

```bat
@echo off
start "IE" "C:/Program Files/Internet Explorer/IEXPLORE.EXE" -k "https://api.dublin2019.com/upgraders"
```

Unfortunately, due to a feature in the membership purchase handling that we didn't discover until registrations were already underway ([this line in the api repository](https://github.com/worldcon75/api/blob/865a2065be1a1e48eb2c8630e32c6ed9477bdb05/kansa/lib/purchase.js#L294), per @eemeli), after a purchase, the user can't log out, so we fell back to killing the browser and restarting the script for each new user logging in to upgrade, instead of risking any instability modding the api server while we were live. Incremental improvement to not get stuck like that would be good, if this system is ever reused.

It worked well enough, despite the hackiness, though. If this is fixed, people logging in via the custom `/upgraders` route are directed back there, so it's okay the kiosk client doesn't have a URL bar or anything else that exposes in plain daylight how it all works for a user. We went to some length to not leak people's email addresses, but it might be good to disable this route until next time it is needed, for instance replacing `/instaloginkeys.js` with a file reading `export default {};`.